### PR TITLE
Add notes on gitlab ci integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,19 @@ jobs:
             curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-$TRAVIS_TAG-1.rockspec"
               https://$ROCKS_USERNAME:$ROCKS_PASSWORD@$ROCKS_SERVER
 ```
+
+## Gitlab CI integration
+
+Add `ROCKS_USERNAME` and `ROCKS_PASSWORD` build variables.
+
+```yaml
+stages:
+  - test
+  - publish
+
+include:
+  remote: https://tarantool.github.io/rocks.tarantool.org/helpers/gitlab-publish-rockspec.yml
+```
+
+That's it. For advanced usage see how to
+[tune external tasks](https://docs.gitlab.com/ee/ci/yaml/#overriding-external-template-values).

--- a/helpers/gitlab-publish-rockspec.yml
+++ b/helpers/gitlab-publish-rockspec.yml
@@ -1,0 +1,20 @@
+variables:
+  ROCK_NAME: $CI_PROJECT_NAME
+
+publish-scm-1-rockspec:
+  stage: publish
+  only:
+    - master
+  script: curl --fail -X PUT -F rockspec=@$ROCK_NAME-scm-1.rockspec
+    https://$ROCKS_USERNAME:$ROCKS_PASSWORD@rocks.tarantool.org
+
+publish-tagged-rockspec:
+  stage: publish
+  only:
+    - tags
+  script: cat $ROCK_NAME-scm-1.rockspec |
+    sed -E
+      -e "s/branch = '.+'/tag = '$CI_COMMIT_TAG'/g"
+      -e "s/version = '.+'/version = '$CI_COMMIT_TAG-1'/g" |
+    curl --fail -X PUT -F "rockspec=@-;filename=$ROCK_NAME-$CI_COMMIT_TAG-1.rockspec"
+      https://$ROCKS_USERNAME:$ROCKS_PASSWORD@rocks.tarantool.org


### PR DESCRIPTION
fixes #1

See https://github.com/tarantool/cartridge-cli/pull/74 for sample usage. ([Here](https://gitlab.com/tarantool/cartridge-cli/pipelines/98681454) is tuned pipeline which imports file from PR's branch instead of master).