### PR TITLE
Add support for Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,68 @@
+name: Test
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-20.04]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      # Setup requirements
+      - name: Cache pip packages
+        uses: actions/cache@v2
+        id: cache-venv
+        with:
+          path: ./venv
+          key: cache-venv-${{ matrix.runs-on }}-01
+      - name: Run pip install
+        run: |
+          python -m venv ./venv && . ./venv/bin/activate
+          pip install -r requirements.txt
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+      - run: echo "$PWD/venv/bin" >> $GITHUB_PATH
+
+      # Run tests
+      - run: pytest
+
+      # Test upload
+      - run: cat > dummy-scm-1.rockspec <<<
+          "package = 'dummy' version = 'scm-1'"
+
+      - name: Run rocks server
+        id: run-rocks-server
+        shell: python
+        run: |
+          import os, sys
+          sys.path.insert(0, os.getcwd())
+
+          import app, tests.conftest
+          setattr(app.boto3, 'client', tests.conftest.S3Mock)
+          setattr(app, 'USER', 'test')
+          setattr(app, 'PASSWORD', 'test')
+
+          pid = os.fork()
+          if pid > 0: # daemonize
+              print('::set-output name=pid::{}'.format(pid))
+              sys.exit(0)
+
+          app.app.run(port=8080)
+
+      - uses: ./github-action
+        with:
+          auth: test:test
+          filename: dummy-scm-1.rockspec
+          rocks-server: http://localhost:8080
+
+      - name: Stop rocks server
+        run: kill -9 "${{ steps.run-rocks-server.outputs.pid }}" || true
+        if: always()

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@ curl --fail \
   -X DELETE -d '{"file_name":"mymodule-scm-1.src.rock"}'
 ```
 
+## Github Actions integration
+
+```yaml
+steps:
+  - uses: actions/checkout@v2
+  - uses: tarantool/rocks.tarantool.org/github-action
+    with:
+      auth: ${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}
+      filename: mymodule-scm-1.rockspec
+```
+
 ## Travis CI integration
 
 ```yaml

--- a/github-action/action.yaml
+++ b/github-action/action.yaml
@@ -1,0 +1,21 @@
+name: 'Upload rocks'
+description: 'Upload a rock to the https://rocks.tarantool.org'
+inputs:
+  auth:
+    description: 'Credentials for the rocks server authentication'
+    required: true
+  filename:
+    description: 'The rock filename to upload'
+    required: true
+  rocks-server:
+    description: 'Custom rocks server URL'
+    default: 'https://rocks.tarantool.org'
+runs:
+  using: 'composite'
+  steps:
+    - shell: bash
+      run: >
+        set -x;
+        curl --fail
+        -u ${{ inputs.auth }} ${{ inputs.rocks-server }}
+        -X PUT -F "rockspec=@${{ inputs.filename }}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,40 @@
+import logging
+from textwrap import dedent
+
+class S3Mock:
+    instance = None
+    def __init__(self, *args, **kwargs):
+        if S3Mock.instance == None:
+            S3Mock.instance = self
+            self.files = {
+                'manifest': dedent("""\
+                    commands = {}
+                    modules = {}
+                    repository = {}
+                """).encode('utf-8')
+            }
+        else:
+            self.files = S3Mock.instance.files
+
+    def generate_presigned_url(self, ClientMethod, Params, ExpiresIn):
+        key = Params.get('Key')
+        if key == '/':
+            key = ''
+
+        return 'https://hb.bizmrd.ru/tarantool/%s' % key
+
+    def get_object(self, Bucket, Key):
+        return {
+            'ResponseMetadata': {'HTTPHeaders': ['content-type']}
+        }
+
+    def download_fileobj(self, Bucket, Key, Bytes):
+        Bytes.write(self.files[Key])
+
+    def upload_fileobj(self, Data, Bucket, Key):
+        logging.info('PUT %s' % Key)
+        self.files[Key] = Data.read()
+
+    def delete_object(self, Bucket, Key):
+        logging.info('DELETE %s' % Key)
+        del self.files[Key]


### PR DESCRIPTION
This patch adds integration with Github Actions.

```yaml
steps:
  - uses: actions/checkout@v2
  - uses: tarantool/rocks.tarantool.org/github-action
    with:
      auth: ${{ secrets.ROCKS_USERNAME }}:${{ secrets.ROCKS_PASSWORD }}
      filename: mymodule-scm-1.rockspec
```

Close #24