### PR TITLE
readme: update setup-tarantool action URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/checkout@v2
-      - uses: rosik/setup-tarantool@v1
+      - uses: tarantool/setup-tarantool@v1
         with:
           tarantool-version: '2.5'
 


### PR DESCRIPTION
It was moved from https://github.com/rosik/setup-tarantool into
tarantool organization on GitHub.

The old URL redirects to the new one, but there is no guarantee that
it'll be so in a future. I guess if Yaroslav will fork the
tarantool/setup-tarantool repository, rosik/setup-tarantool will point
to the fork. It is more safe to use the new URL.

Reported by Vladislav Grubov (@ochaton).