### PR TITLE
Bump Flask and Flask-HTTPAuth package versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 boto3==1.18.34
-Flask==1.1.1
+Flask==2.2.2
 Flask-HTTPAuth==3.3.0
 gunicorn==20.1.0
 lupa==1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.18.34
 Flask==2.2.2
-Flask-HTTPAuth==3.3.0
+Flask-HTTPAuth==4.7.0
 gunicorn==20.1.0
 lupa==1.10
 pytest==6.2.5

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -239,9 +239,11 @@ def test_brake_manifest(app):
     answer = json.loads(response.content)
     assert response.status_code == 400
     assert answer.get('message') == 'Some unexpected error'
-    assert list(S3Mock.instance.files.keys()) == ['manifest', 'fizz-buzz-scm-1.rockspec', '21-09.log']
 
     audit_file_name = f'{datetime.today().strftime("%y-%m")}.log'
+    assert list(sorted(S3Mock.instance.files.keys())) == \
+           list(sorted(['manifest', 'fizz-buzz-scm-1.rockspec', audit_file_name]))
+
     audit_log_list = S3Mock.instance.files[audit_file_name].decode('utf-8').strip().split('\n')
     audit_log_entry = audit_log_list[2]
     assert len(audit_log_list) == 3  # rock + manifest + error


### PR DESCRIPTION
This patch is intended to fix the following issue:

    E   ImportError: cannot import name 'escape' from 'jinja2'

Jinja is a dependency of Flask and Flask 1.x.x uses the escape module
from Jinja, however recently support for the escape module was dropped
in newer versions of Jinja.

To fix this issue, simply update to the newer version of Flask 2.x.x
where Flask no longer uses the escape module from Jinja.

Also, update Flask-HTTPAuth and fix `test_brake_manifest` test case.