### PR TITLE
Adapt deploy.yml workflow for working with Dokku

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-ruby@v1
-      - run: gem install dpl-heroku
-      - run: dpl
-          --provider=heroku
-          --app=tarantool-rocks
-          --api-key=${{ secrets.DEPLOYMENT_API_KEY }}
+        with:
+          fetch-depth: 0
+      - uses: idoberko2/dokku-deploy-github-action@v1
+        with:
+          ssh-private-key: ${{ secrets.DOKKU_SSH_PRIVATE_KEY }}
+          dokku-host: ${{ secrets.DOKKU_HOST }}
+          app-name: rocks
+          git-push-flags: --force


### PR DESCRIPTION
The `rocks.tarantool.org` server was deployed to `Dokku` a few months
ago, but we forgot to adapt the deploy.yml workflow according to that
change. Now it is fixed.

Closes #50 

Testing: [passed](https://github.com/tarantool/rocks.tarantool.org/runs/8193422614?check_suite_focus=true)